### PR TITLE
Fix site loading issue nav bar only

### DIFF
--- a/start-server.sh
+++ b/start-server.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Starting AI Real Estate Playbook web server..."
+echo "The site will be available at: http://localhost:8000"
+echo "Press Ctrl+C to stop the server"
+echo ""
+python3 -m http.server 8000


### PR DESCRIPTION
Add `start-server.sh` script to easily run a local web server, resolving content loading issues due to CORS.

The site's dynamic components (e.g., content sections) are loaded via JavaScript from separate HTML files. When `index.html` is opened directly in a browser using the `file://` protocol, browsers block these requests due to security restrictions (CORS). Running the site through a web server (e.g., `http://localhost:8000`) bypasses this restriction, allowing all content to load correctly. This script provides a convenient way to start the necessary web server.